### PR TITLE
Wayland-native computer control backend + fix silent .gitignore secret leak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,12 +5,20 @@
 # never be.
 
 # ── Secrets. Committing any of these publishes them. ──────────────────────────
-config/api_keys.json          # your Gemini API key, plus per-plugin credentials
-config/certs/                 # the dashboard's TLS private key and certificate
-config/whatsapp_web/          # a LINKED WhatsApp session — committing it hands
-                              # somebody your WhatsApp account, not just a key
-**/token*.json                # Google OAuth tokens (Gmail / Calendar plugins)
-**/client_secret*.json        # Google OAuth client secrets
+# NOTE: git does NOT support inline `#` comments — `pattern  # comment` is
+# read as a literal filename, so the pattern silently never matches. Keep
+# comments on their own lines (this previously left api_keys.json committable).
+# your Gemini API key, plus per-plugin credentials
+config/api_keys.json
+# the dashboard's TLS private key and certificate
+config/certs/
+# a LINKED WhatsApp session — committing it hands somebody your WhatsApp
+# account, not just a key
+config/whatsapp_web/
+# Google OAuth tokens (Gmail / Calendar plugins)
+**/token*.json
+# Google OAuth client secrets
+**/client_secret*.json
 *credentials*.json
 .env
 .env.*

--- a/actions/computer_control.py
+++ b/actions/computer_control.py
@@ -29,6 +29,13 @@ try:
 except ImportError:
     _PYPERCLIP = False
 
+try:
+    from core import wayland as _wl
+    _WAYLAND = _wl.backend_available()
+except Exception:
+    _wl = None
+    _WAYLAND = False
+
 def _base_dir() -> Path:
     if getattr(sys, "frozen", False):
         return Path(sys.executable).parent
@@ -155,6 +162,8 @@ def _user_profile() -> dict:
     return {}
 
 def _type(text: str, interval: float = 0.03) -> str:
+    if _WAYLAND:
+        return _wl.type_text(text)
     _require_pyautogui()
     time.sleep(0.3)
     pyautogui.typewrite(text, interval=interval)
@@ -162,6 +171,11 @@ def _type(text: str, interval: float = 0.03) -> str:
 
 
 def _smart_type(text: str, clear_first: bool = True) -> str:
+    if _WAYLAND:
+        if clear_first:
+            _wl.clear_field()
+            time.sleep(0.1)
+        return _wl.type_text(text)
     _require_pyautogui()
     if clear_first:
         _clear_field()
@@ -179,6 +193,11 @@ def _smart_type(text: str, clear_first: bool = True) -> str:
 
 
 def _click(x=None, y=None, button: str = "left", clicks: int = 1) -> str:
+    if _WAYLAND:
+        if x is not None and y is not None:
+            _wl.mouse_move(int(x), int(y))
+            time.sleep(0.15)
+        return _wl.mouse_click(button, clicks)
     _require_pyautogui()
     if x is not None and y is not None:
         pyautogui.click(x, y, button=button, clicks=clicks)
@@ -188,18 +207,24 @@ def _click(x=None, y=None, button: str = "left", clicks: int = 1) -> str:
 
 
 def _hotkey(*keys) -> str:
+    if _WAYLAND:
+        return _wl.hotkey(*keys)
     _require_pyautogui()
     pyautogui.hotkey(*keys)
     return f"Hotkey: {'+'.join(keys)}"
 
 
 def _press(key: str) -> str:
+    if _WAYLAND:
+        return _wl.press_key(key)
     _require_pyautogui()
     pyautogui.press(key)
     return f"Pressed: {key}"
 
 
 def _scroll(direction: str = "down", amount: int = 3) -> str:
+    if _WAYLAND:
+        return _wl.scroll(direction, amount)
     _require_pyautogui()
     vertical   = direction in ("up", "down")
     clicks     = amount if direction in ("up", "right") else -amount
@@ -208,12 +233,22 @@ def _scroll(direction: str = "down", amount: int = 3) -> str:
 
 
 def _move(x: int, y: int, duration: float = 0.3) -> str:
+    if _WAYLAND:
+        return _wl.mouse_move(x, y)
     _require_pyautogui()
     pyautogui.moveTo(x, y, duration=duration)
     return f"Mouse → ({x}, {y})"
 
 
 def _drag(x1: int, y1: int, x2: int, y2: int, duration: float = 0.5) -> str:
+    if _WAYLAND:
+        _wl.mouse_move(x1, y1)
+        time.sleep(0.2)
+        _wl.mouse_down("left")
+        _wl.mouse_move(x2, y2)
+        time.sleep(0.2)
+        _wl.mouse_up("left")
+        return f"Dragged ({x1},{y1}) → ({x2},{y2})"
     _require_pyautogui()
     pyautogui.moveTo(x1, y1, duration=0.2)
     pyautogui.dragTo(x2, y2, duration=duration, button="left")
@@ -221,6 +256,8 @@ def _drag(x1: int, y1: int, x2: int, y2: int, duration: float = 0.5) -> str:
 
 
 def _clipboard_get() -> str:
+    if _WAYLAND:
+        return _wl.clipboard_get()
     if _PYPERCLIP:
         return pyperclip.paste()
     _hotkey("ctrl", "c")
@@ -229,6 +266,8 @@ def _clipboard_get() -> str:
 
 
 def _clipboard_paste(text: str) -> str:
+    if _WAYLAND:
+        return _wl.clipboard_paste(text)
     if _PYPERCLIP:
         pyperclip.copy(text)
         time.sleep(0.1)
@@ -240,14 +279,19 @@ def _clipboard_paste(text: str) -> str:
 
 
 def _screenshot(save_path: str | None = None) -> str:
-    _require_pyautogui()
     path = _safe_screenshot_path(save_path)
+    if _WAYLAND:
+        path.write_bytes(_wl.screenshot_png())
+        return f"Screenshot saved: {path}"
+    _require_pyautogui()
     img  = pyautogui.screenshot()
     img.save(str(path))
     return f"Screenshot saved: {path}"
 
 
 def _clear_field() -> str:
+    if _WAYLAND:
+        return _wl.clear_field()
     _require_pyautogui()
     select_key = "command" if _get_os() == "mac" else "ctrl"
     pyautogui.hotkey(select_key, "a")
@@ -286,6 +330,11 @@ def _focus_window(title: str) -> str:
             return f"focus_window (macOS) failed: {e}"
 
     if os_name == "linux":
+        if _WAYLAND:
+            try:
+                return _wl.focus_window(title)
+            except Exception:
+                pass
         try:
             result = subprocess.run(
                 ["wmctrl", "-a", title],
@@ -320,12 +369,16 @@ def _screen_find(description: str) -> tuple[int, int] | None:
         from google import genai
         from google.genai import types as gtypes
 
-        _require_pyautogui()
-        w, h  = pyautogui.size()
-        img   = pyautogui.screenshot()
-        buf   = io.BytesIO()
-        img.save(buf, format="PNG")
-        image_bytes = buf.getvalue()
+        if _WAYLAND:
+            w, h = _wl.screen_size()
+            image_bytes = _wl.screenshot_png()
+        else:
+            _require_pyautogui()
+            w, h  = pyautogui.size()
+            img   = pyautogui.screenshot()
+            buf   = io.BytesIO()
+            img.save(buf, format="PNG")
+            image_bytes = buf.getvalue()
 
         client = genai.Client(api_key=api_key)
         prompt = (
@@ -399,6 +452,7 @@ def computer_control(
       wait          — sleep N seconds
       clear_field   — select-all + delete
       focus_window  — bring window to foreground
+      workspace     — switch Hyprland workspace 1..9 (Wayland)
       screen_find   — AI element finder (returns x,y)
       screen_click  — AI element finder + click
       random_data   — generate fake form data
@@ -492,6 +546,11 @@ def computer_control(
         if action == "focus_window":
             return _focus_window(params.get("title", ""))
 
+        if action == "workspace":
+            if _WAYLAND:
+                return _wl.workspace(int(params.get("number", 1)))
+            return "workspace switching needs a Wayland session on Linux"
+
         if action == "random_data":
             dt     = params.get("type", "name")
             result = _random_data(dt)
@@ -523,7 +582,7 @@ TOOL = {
         "properties": {
             "action": {
                 "type": "STRING",
-                "description": "type | smart_type | click | double_click | right_click | hotkey | press | scroll | move | copy | paste | screenshot | wait | clear_field | focus_window | screen_find | screen_click | random_data | user_data"
+                "description": "type | smart_type | click | double_click | right_click | hotkey | press | scroll | move | copy | paste | screenshot | wait | clear_field | focus_window | workspace | screen_find | screen_click | random_data | user_data"
             },
             "text": {
                 "type": "STRING",
@@ -560,6 +619,10 @@ TOOL = {
             "title": {
                 "type": "STRING",
                 "description": "Window title for focus_window"
+            },
+            "number": {
+                "type": "INTEGER",
+                "description": "Workspace number 1..9 for workspace"
             },
             "description": {
                 "type": "STRING",

--- a/actions/computer_settings.py
+++ b/actions/computer_settings.py
@@ -323,8 +323,21 @@ def open_task_manager():
     elif _OS == "Darwin":
         subprocess.Popen(["open", "-a", "Activity Monitor"])
     else:
-        for cmd in [["gnome-system-monitor"], ["xfce4-taskmanager"], ["htop"]]:
-            if subprocess.run(["which", cmd[0]], capture_output=True).returncode == 0:
+        # Prefer native GUI monitors; fall back to btop in a terminal.
+        # (gnome-system-monitor is often absent outside GNOME.)
+        import shutil
+        for cmd in [["missioncenter"], ["gnome-system-monitor"],
+                    ["xfce4-taskmanager"]]:
+            if shutil.which(cmd[0]):
+                subprocess.Popen(cmd)
+                return
+        for term in ("kitty", "foot", "alacritty", "gnome-terminal",
+                     "xfce4-terminal", "konsole"):
+            if shutil.which(term) and shutil.which("btop"):
+                subprocess.Popen([term, "-e", "btop"])
+                return
+        for cmd in [["htop"]]:
+            if shutil.which(cmd[0]):
                 subprocess.Popen(cmd)
                 break
 

--- a/actions/screen_processor.py
+++ b/actions/screen_processor.py
@@ -86,6 +86,13 @@ def _compress(img_bytes: bytes, source_format: str = "PNG") -> tuple[bytes, str]
 
 
 def _capture_screen() -> tuple[bytes, str]:
+    # Wayland first: mss only sees XWayland (black frame on Hyprland).
+    try:
+        from core import wayland as _wl
+        if _wl.backend_available():
+            return _compress(_wl.screenshot_png(), "PNG")
+    except Exception:
+        pass
 
     if not _MSS:
         raise RuntimeError("mss is not installed. Run: pip install mss")

--- a/core/wayland.py
+++ b/core/wayland.py
@@ -1,0 +1,360 @@
+"""
+Wayland-native backend for computer control (Hyprland-first).
+
+Why this exists: the default primitives in actions/computer_control.py speak
+X11 (PyAutoGUI) and the screen capture in actions/screen_processor.py speaks
+X11 (mss). Under a rootless XWayland session both silently misbehave:
+
+  * mss captures XWayland's empty root window (pure black frame),
+  * PyAutoGUI moves an X11 ghost pointer — position() even confirms moves
+    that never reach the real Wayland cursor.
+
+This module routes the same operations through Wayland-native tools instead:
+
+  * eyes    → grim (real compositor frame)
+  * mouse   → ydotool daemon, absolute mode with auto-calibrated scale
+              (ydotool's absolute range rarely matches the screen 1:1;
+              we probe once and cache the factor)
+  * typing  → wtype
+  * keys    → ydotool raw evdev keycodes (names mapped below)
+  * windows → hyprctl dispatch
+  * clipboard → wl-copy / wl-paste
+
+Everything here shells out to small CLI tools and returns plain strings, so
+callers can prefer it and fall back to the X11 path when it is unavailable.
+No new Python dependencies.
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import time
+
+# ── detection ────────────────────────────────────────────────────────────────
+
+_HYPRCTL = shutil.which("hyprctl")
+_GRIM = shutil.which("grim")
+_YDOTOOL = shutil.which("ydotool")
+_WTYPE = shutil.which("wtype")
+_WL_COPY = shutil.which("wl-copy")
+_WL_PASTE = shutil.which("wl-paste")
+
+
+def is_wayland() -> bool:
+    """True when a Wayland compositor session owns the display."""
+    return bool(os.environ.get("WAYLAND_DISPLAY"))
+
+
+def is_hyprland() -> bool:
+    return bool(os.environ.get("HYPRLAND_INSTANCE_SIGNATURE")) and bool(_HYPRCTL)
+
+
+def backend_available() -> bool:
+    """True when the full Wayland backend (eyes + hands) is usable."""
+    return bool(is_wayland() and _GRIM and _YDOTOOL and _WTYPE)
+
+
+def _run(args: list[str], timeout: int = 10) -> subprocess.CompletedProcess:
+    return subprocess.run(args, capture_output=True, timeout=timeout)
+
+
+# ── eyes ─────────────────────────────────────────────────────────────────────
+
+def screen_size() -> tuple[int, int]:
+    """Focused monitor size in screen pixels (falls back to 1366×768)."""
+    if _HYPRCTL:
+        try:
+            monitors = json.loads(_run([_HYPRCTL, "monitors", "-j"]).stdout or b"[]")
+            for m in monitors:
+                if m.get("focused"):
+                    return int(m["width"]), int(m["height"])
+            if monitors:
+                return int(monitors[0]["width"]), int(monitors[0]["height"])
+        except Exception:
+            pass
+    return 1366, 768
+
+
+def screenshot_png() -> bytes:
+    """Capture the real compositor frame; raises on failure."""
+    if not _GRIM:
+        raise RuntimeError("grim not installed (pacman -S grim)")
+    with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp:
+        path = tmp.name
+    try:
+        result = _run([_GRIM, path])
+        if result.returncode != 0:
+            raise RuntimeError(f"grim failed: {result.stderr.decode()[:200]}")
+        with open(path, "rb") as f:
+            return f.read()
+    finally:
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+
+
+# ── mouse ────────────────────────────────────────────────────────────────────
+
+_SCALE: float | None = None
+
+
+def _abs_scale() -> float:
+    """Probe ydotool's absolute range with a two-point move.
+
+    A single-point probe breaks when the cursor starts right of the probe
+    point (negative delta -> negative scale -> clamped garbage). Two
+    same-direction moves give a sign-correct factor. Result cached."""
+    global _SCALE
+    if _SCALE is not None:
+        return _SCALE
+    _SCALE = 1.0
+    try:
+        _run([_YDOTOOL, "mousemove", "-a", "-x", "200", "-y", "200"])
+        time.sleep(0.3)
+        x1, _ = cursor_pos()
+        _run([_YDOTOOL, "mousemove", "-a", "-x", "400", "-y", "400"])
+        time.sleep(0.3)
+        x2, _ = cursor_pos()
+        dx = x2 - x1
+        if abs(dx) > 5:
+            _SCALE = dx / 200.0
+    except Exception:
+        pass
+    return _SCALE
+
+
+def cursor_pos() -> tuple[int, int]:
+    if _HYPRCTL:
+        try:
+            out = _run([_HYPRCTL, "cursorpos"]).stdout.decode().strip()
+            x, y = out.split(",")
+            return int(x.strip()), int(y.strip())
+        except Exception:
+            pass
+    return 0, 0
+
+
+def mouse_move(x: int, y: int) -> str:
+    if not _YDOTOOL:
+        raise RuntimeError("ydotool not installed / daemon not running")
+    scale = _abs_scale()
+    ax, ay = int(x / scale), int(y / scale)
+    result = _run([_YDOTOOL, "mousemove", "-a", "-x", str(ax), "-y", str(ay)])
+    if result.returncode != 0:
+        raise RuntimeError(f"ydotool mousemove failed: {result.stderr.decode()[:200]}")
+    time.sleep(0.15)
+    px, py = cursor_pos()
+    return f"Mouse → ({x}, {y}) [at {px},{py}]"
+
+
+_CLICK_BUTTONS = {"left": "C0", "right": "C1", "middle": "C2"}
+
+
+def mouse_down(button: str = "left") -> None:
+    if not _YDOTOOL:
+        raise RuntimeError("ydotool not installed / daemon not running")
+    code = {"left": "0x40", "right": "0x41", "middle": "0x42"}.get(button, "0x40")
+    result = _run([_YDOTOOL, "click", code])
+    if result.returncode != 0:
+        raise RuntimeError(f"ydotool button-down failed: {result.stderr.decode()[:200]}")
+
+
+def mouse_up(button: str = "left") -> None:
+    if not _YDOTOOL:
+        raise RuntimeError("ydotool not installed / daemon not running")
+    code = {"left": "0x80", "right": "0x81", "middle": "0x82"}.get(button, "0x80")
+    result = _run([_YDOTOOL, "click", code])
+    if result.returncode != 0:
+        raise RuntimeError(f"ydotool button-up failed: {result.stderr.decode()[:200]}")
+
+
+def mouse_click(button: str = "left", clicks: int = 1) -> str:
+    if not _YDOTOOL:
+        raise RuntimeError("ydotool not installed / daemon not running")
+    code = _CLICK_BUTTONS.get(button, "C0")
+    args = [_YDOTOOL, "click"]
+    if clicks > 1:
+        args += ["-r", str(clicks)]
+    args.append(code)
+    result = _run(args)
+    if result.returncode != 0:
+        raise RuntimeError(f"ydotool click failed: {result.stderr.decode()[:200]}")
+    label = "Double-click" if clicks == 2 else "Clicked"
+    return f"{label} [{button}]"
+
+
+def scroll(direction: str = "down", amount: int = 3) -> str:
+    if not _YDOTOOL:
+        raise RuntimeError("ydotool not installed / daemon not running")
+    if direction == "up":
+        dx, dy = 0, -amount
+    elif direction == "down":
+        dx, dy = 0, amount
+    elif direction == "left":
+        dx, dy = -amount, 0
+    else:  # right
+        dx, dy = amount, 0
+    result = _run([_YDOTOOL, "mousemove", "-w", "--", str(dx), str(dy)])
+    if result.returncode != 0:
+        raise RuntimeError(f"ydotool wheel failed: {result.stderr.decode()[:200]}")
+    return f"Scrolled {direction} ×{amount}"
+
+
+# ── keyboard ─────────────────────────────────────────────────────────────────
+
+# evdev keycodes (KEY_*): ydotool key speaks raw codes, not names.
+_KEYCODES = {
+    "esc": 1, "1": 2, "2": 3, "3": 4, "4": 5, "5": 6, "6": 7, "7": 8,
+    "8": 9, "9": 10, "0": 11, "backspace": 14, "tab": 15,
+    "q": 16, "w": 17, "e": 18, "r": 19, "t": 20, "y": 21, "u": 22,
+    "i": 23, "o": 24, "p": 25, "enter": 28, "ctrl": 29,
+    "a": 30, "s": 31, "d": 32, "f": 33, "g": 34, "h": 35, "j": 36,
+    "k": 37, "l": 38, "semicolon": 39, "shift": 42, "z": 44, "x": 45,
+    "c": 46, "v": 47, "b": 48, "n": 49, "m": 50, "comma": 51,
+    "dot": 52, "period": 52, "slash": 53, "alt": 56, "space": 57,
+    "f5": 63, "home": 102, "up": 103, "pageup": 104, "left": 105,
+    "right": 106, "end": 107, "down": 108, "pagedown": 109,
+    "delete": 111, "super": 125, "win": 125, "command": 125,
+}
+
+
+def _key_seq(names: list[str], down: bool = True) -> list[str]:
+    seq: list[str] = []
+    for name in names:
+        code = _KEYCODES.get(name.lower())
+        if code is None:
+            raise ValueError(f"unknown key name for ydotool: '{name}'")
+        seq.append(f"{code}:{'1' if down else '0'}")
+    return seq
+
+
+def press_key(key: str) -> str:
+    if not _YDOTOOL:
+        raise RuntimeError("ydotool not installed / daemon not running")
+    seq = _key_seq([key])
+    result = _run([_YDOTOOL, "key"] + seq + _key_seq([key], down=False))
+    if result.returncode != 0:
+        raise RuntimeError(f"ydotool key failed: {result.stderr.decode()[:200]}")
+    return f"Pressed: {key}"
+
+
+def hotkey(*keys: str) -> str:
+    if not _YDOTOOL:
+        raise RuntimeError("ydotool not installed / daemon not running")
+    names = list(keys)
+    seq = _key_seq(names, down=True) + _key_seq(list(reversed(names)), down=False)
+    result = _run([_YDOTOOL, "key"] + seq)
+    if result.returncode != 0:
+        raise RuntimeError(f"ydotool hotkey failed: {result.stderr.decode()[:200]}")
+    return f"Hotkey: {'+'.join(names)}"
+
+
+def type_text(text: str) -> str:
+    if not _WTYPE:
+        raise RuntimeError("wtype not installed (pacman -S wtype)")
+    time.sleep(0.2)
+    result = _run([_WTYPE, "--", text])
+    if result.returncode != 0:
+        raise RuntimeError(f"wtype failed: {result.stderr.decode()[:200]}")
+    clipped = text[:60] + ("…" if len(text) > 60 else "")
+    return f"Typed: {clipped}"
+
+
+def clear_field() -> str:
+    hotkey("ctrl", "a")
+    time.sleep(0.1)
+    press_key("delete")
+    return "Field cleared"
+
+
+# ── clipboard ────────────────────────────────────────────────────────────────
+
+def clipboard_get() -> str:
+    if not _WL_PASTE:
+        raise RuntimeError("wl-paste not installed (pacman -S wl-clipboard)")
+    result = _run([_WL_PASTE])
+    if result.returncode != 0:
+        raise RuntimeError(f"wl-paste failed: {result.stderr.decode()[:200]}")
+    return result.stdout.decode()
+
+
+def clipboard_paste(text: str) -> str:
+    if not _WL_COPY:
+        raise RuntimeError("wl-copy not installed (pacman -S wl-clipboard)")
+    proc = subprocess.run([_WL_COPY], input=text.encode(),
+                          capture_output=True, timeout=10)
+    if proc.returncode != 0:
+        raise RuntimeError(f"wl-copy failed: {proc.stderr.decode()[:200]}")
+    time.sleep(0.1)
+    hotkey("ctrl", "v")
+    clipped = text[:60] + ("…" if len(text) > 60 else "")
+    return f"Pasted: {clipped}"
+
+
+# ── windows & workspaces ───────────────────────────────────────────────────
+# NOTE (Hyprland ≥0.56): plain `hyprctl dispatch <name> <args>` is broken
+# upstream (the CLI wraps it in a Lua shorthand that fails to parse), and the
+# Lua table has no direct workspace-goto. We drive the compositor through its
+# own default keybinds (SUPER+1..9) instead — robust across builds.
+
+def _hypr_query(*args: str):
+    if not _HYPRCTL:
+        raise RuntimeError("hyprctl not available (not on Hyprland?)")
+    result = _run([_HYPRCTL, *args])
+    if result.returncode != 0:
+        raise RuntimeError(f"hyprctl failed: {result.stderr.decode()[:200]}")
+    return json.loads(result.stdout or b"null")
+
+
+def workspace(number: int) -> str:
+    if not 1 <= int(number) <= 9:
+        raise ValueError("workspace number must be 1..9 (SUPER+1..9 binds)")
+    hotkey("super", str(int(number)))
+    time.sleep(0.4)
+    return f"Switched to workspace {int(number)}"
+
+
+def focus_window(title: str) -> str:
+    # No working focus dispatch on this build: locate the window's workspace
+    # via the (working) query API and jump there.
+    clients = _hypr_query("clients", "-j") or []
+    needle = title.lower()
+    for client in clients:
+        hay = f"{client.get('title', '')} {client.get('class', '')}".lower()
+        if needle and needle in hay:
+            ws = client.get("workspace", {}).get("id")
+            if ws:
+                workspace(int(ws))
+                return f"Focused window: {title} (workspace {ws})"
+    return f"No window matching '{title}' found"
+
+
+# ── task manager ─────────────────────────────────────────────────────────────
+
+_TASK_MANAGER_CHAIN = [
+    ["missioncenter"],
+    ["gnome-system-monitor"],
+    ["xfce4-taskmanager"],
+]
+
+
+def open_task_manager() -> str:
+    for cmd in _TASK_MANAGER_CHAIN:
+        if shutil.which(cmd[0]):
+            subprocess.Popen(cmd, stdout=subprocess.DEVNULL,
+                             stderr=subprocess.DEVNULL)
+            return f"Opened task manager: {cmd[0]}"
+    for term in ("kitty", "foot", "xdg-terminal-exec"):
+        if shutil.which(term):
+            if term == "xdg-terminal-exec":
+                subprocess.Popen([term, "btop"], stdout=subprocess.DEVNULL,
+                                 stderr=subprocess.DEVNULL)
+            else:
+                subprocess.Popen([term, "-e", "btop"], stdout=subprocess.DEVNULL,
+                                 stderr=subprocess.DEVNULL)
+            return f"Opened task manager: btop in {term}"
+    return "No task manager found (missioncenter/gnome-system-monitor/btop)"


### PR DESCRIPTION
## What
On Wayland (tested: Hyprland 0.56 + CachyOS) the X11 primitives silently misbehave:

- **Blind**: mss captures XWayland's empty root window (verified: 1366x768 frame of pure black). Native Wayland windows are invisible.
- **Paralyzed + lied to**: PyAutoGUI moves an X11 ghost pointer. Worse, position() confirms moves that never reach the real Wayland cursor, so the assistant plans on false feedback.
- **Wrong OS instincts**: 'task manager' resolves to gnome-system-monitor, absent outside GNOME.

## Changes
- **New core/wayland.py** (no new Python deps, all X11 paths kept as fallback):
  - eyes: grim screenshots + focused-monitor size via hyprctl monitors -j
  - mouse: ydotool absolute mode with a **two-point auto-calibration probe** (single-point probes go negative when the cursor starts right of the probe point; my setup needed a 2.0x factor, verified pixel-accurate via hyprctl cursorpos)
  - typing: wtype; hotkeys/keys: ydotool raw evdev map; clipboard: wl-copy/wl-paste
  - workspaces: SUPER+1..9 keybinds — plain hyprctl dispatch is broken on Hyprland >= 0.56 (Lua-shorthand parse error, verified down to the socket), and the Lua table has no workspace-goto
  - task manager: missioncenter-first chain with terminal-btop fallback
- **computer_control**: all primitives route via the backend on Wayland; screen_find uses real frame + size; new additive `workspace` action (1..9).
- **screen_processor._capture_screen**: grim first, mss fallback.
- **computer_settings.open_task_manager**: missioncenter-first chain.
- **.gitignore fix (separate commit)**: git has no inline `#` comments, so every Secrets line (config/api_keys.json, WhatsApp sessions, OAuth tokens) silently never matched — verified with git check-ignore. Comments moved to own lines.

## Verified on
Hyprland 0.56.2 / CachyOS, 1366x768: real (non-black) captures, pixel-accurate moves, live workspace switches, Mission Center launch. Typing via wtype proven through daily use of the same tool.

## Requires on Linux
grim, ydotool (daemon running), wtype, wl-clipboard — all standard repo packages.
